### PR TITLE
fix: update tracking method to use 'page-view' for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ yarn add journey-footprints
 <script src="https://unpkg.com/journey-footprints/dist/index.global.js"></script>
 <script>
   const tracker = JourneyFootprints.createFootprints({ user: '42' });
-  tracker.track('pageview');
+  tracker.track('page-view');
 </script>
 ```
 
@@ -37,7 +37,7 @@ yarn add journey-footprints
 import { createFootprints } from 'journey-footprints';
 
 const tracker = createFootprints({ user: '42' });
-tracker.track('pageview');
+tracker.track('page-view');
 ```
 
 ### Vue
@@ -48,7 +48,7 @@ import { createFootprints } from 'journey-footprints';
 export default {
   setup() {
     const tracker = createFootprints();
-    tracker.track('pageview');
+    tracker.track('page-view');
   }
 };
 ```
@@ -59,7 +59,7 @@ export default {
 <script>
   import { createFootprints } from 'journey-footprints';
   const tracker = createFootprints();
-  tracker.track('pageview');
+  tracker.track('page-view');
 </script>
 ```
 


### PR DESCRIPTION
This pull request updates the usage examples in the `README.md` to use the correct event name for tracking page views. The event name has been changed from `'pageview'` to `'page-view'` across all code snippets to reflect the current API.

**Documentation updates:**

* Changed all instances of `tracker.track('pageview')` to `tracker.track('page-view')` in the JavaScript, ES module, Vue Composition API, and Vue SFC examples in `README.md`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L28-R28) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L40-R40) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L51-R51) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L62-R62)