### PR TITLE
docs: add multilingual readme and test example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,29 @@
 # JourneyFootprints.js
 
-Lightweight JavaScript tracker focused on capturing session and UTM data. Designed with DRY, KISS and SOLID principles, it runs in browsers and can be consumed via CDN or installed through npm, pnpm or yarn.
+> Português | [English](#english) | [Español](#español)
 
-## Features
+## Português
 
-- Capture `sessionId`, `user` and language
-- Read UTM parameters from the URL or accept them explicitly
-- Send events to a configurable endpoint
-- Tiny footprint and framework agnostic
+Biblioteca JavaScript leve focada na captura de dados de sessão e parâmetros UTM. Ela roda no navegador e pode ser consumida via CDN ou instalada com npm, pnpm ou yarn.
 
-## Installation
+### Recursos
+
+- Captura `sessionId`, `user` e idioma
+- Lê parâmetros UTM da URL ou os aceita explicitamente
+- Envia eventos para um endpoint configurável
+- Pequeno e agnóstico de framework
+
+### Instalação
 
 ```bash
 npm install journey-footprints
-# or
+# ou
 pnpm add journey-footprints
-# or
+# ou
 yarn add journey-footprints
 ```
 
-### CDN
+#### CDN
 
 ```html
 <script src="https://unpkg.com/journey-footprints/dist/index.global.js"></script>
@@ -29,7 +33,7 @@ yarn add journey-footprints
 </script>
 ```
 
-## Usage
+## Uso
 
 ### React
 
@@ -79,6 +83,106 @@ createFootprints(options?: {
 })
 ```
 
+Retorna um rastreador com métodos:
+
+- `track(event, data?)` – envia um evento
+- `setUser(user)`
+- `setSessionId(sessionId)`
+- `getSessionId()`
+
+O idioma padrão é o do navegador quando não informado.
+
+## Testes com dados fictícios
+
+```bash
+npm test
+```
+
+Os testes utilizam uma implementação fictícia de `fetch` para validar o envio de eventos sem depender de um servidor real.
+
+---
+
+## English
+
+Lightweight JavaScript tracker focused on capturing session and UTM data. It runs in browsers and can be consumed via CDN or installed through npm, pnpm or yarn.
+
+### Features
+
+- Capture `sessionId`, `user` and language
+- Read UTM parameters from the URL or accept them explicitly
+- Send events to a configurable endpoint
+- Tiny footprint and framework agnostic
+
+### Installation
+
+```bash
+npm install journey-footprints
+# or
+pnpm add journey-footprints
+# or
+yarn add journey-footprints
+```
+
+#### CDN
+
+```html
+<script src="https://unpkg.com/journey-footprints/dist/index.global.js"></script>
+<script>
+  const tracker = JourneyFootprints.createFootprints({ user: '42' });
+  tracker.track('page-view');
+</script>
+```
+
+### Usage
+
+#### React
+
+```jsx
+import { createFootprints } from 'journey-footprints';
+
+const tracker = createFootprints({ user: '42' });
+tracker.track('page-view');
+```
+
+#### Vue
+
+```js
+import { createFootprints } from 'journey-footprints';
+
+export default {
+  setup() {
+    const tracker = createFootprints();
+    tracker.track('page-view');
+  }
+};
+```
+
+#### Svelte
+
+```svelte
+<script>
+  import { createFootprints } from 'journey-footprints';
+  const tracker = createFootprints();
+  tracker.track('page-view');
+</script>
+```
+
+### API
+
+```ts
+createFootprints(options?: {
+  endpoint?: string;
+  sessionId?: string | null;
+  user?: string;
+  utmSource?: string;
+  utmMedium?: string;
+  utmCampaign?: string;
+  utmTerm?: string;
+  utmContent?: string;
+  language?: string;
+})
+```
+
 Returns a tracker with methods:
 
 - `track(event, data?)` – send an event
@@ -87,3 +191,111 @@ Returns a tracker with methods:
 - `getSessionId()`
 
 Language defaults to the browser language when not provided.
+
+### Testing with fake data
+
+```bash
+npm test
+```
+
+The tests use a fake `fetch` implementation to validate event delivery without relying on a real server.
+
+---
+
+## Español
+
+Rastreador ligero de JavaScript enfocado en capturar datos de sesión y parámetros UTM. Funciona en navegadores y puede consumirse mediante CDN o instalarse con npm, pnpm o yarn.
+
+### Características
+
+- Captura `sessionId`, `user` e idioma
+- Lee parámetros UTM de la URL o los acepta explícitamente
+- Envía eventos a un endpoint configurable
+- Huella pequeña y agnóstico del framework
+
+### Instalación
+
+```bash
+npm install journey-footprints
+# o
+pnpm add journey-footprints
+# o
+yarn add journey-footprints
+```
+
+#### CDN
+
+```html
+<script src="https://unpkg.com/journey-footprints/dist/index.global.js"></script>
+<script>
+  const tracker = JourneyFootprints.createFootprints({ user: '42' });
+  tracker.track('page-view');
+</script>
+```
+
+### Uso
+
+#### React
+
+```jsx
+import { createFootprints } from 'journey-footprints';
+
+const tracker = createFootprints({ user: '42' });
+tracker.track('page-view');
+```
+
+#### Vue
+
+```js
+import { createFootprints } from 'journey-footprints';
+
+export default {
+  setup() {
+    const tracker = createFootprints();
+    tracker.track('page-view');
+  }
+};
+```
+
+#### Svelte
+
+```svelte
+<script>
+  import { createFootprints } from 'journey-footprints';
+  const tracker = createFootprints();
+  tracker.track('page-view');
+</script>
+```
+
+### API
+
+```ts
+createFootprints(options?: {
+  endpoint?: string;
+  sessionId?: string | null;
+  user?: string;
+  utmSource?: string;
+  utmMedium?: string;
+  utmCampaign?: string;
+  utmTerm?: string;
+  utmContent?: string;
+  language?: string;
+})
+```
+
+Devuelve un rastreador con métodos:
+
+- `track(event, data?)` – envía un evento
+- `setUser(user)`
+- `setSessionId(sessionId)`
+- `getSessionId()`
+
+El idioma predeterminado es el del navegador cuando no se proporciona.
+
+### Pruebas con datos ficticios
+
+```bash
+npm test
+```
+
+Las pruebas utilizan una implementación ficticia de `fetch` para validar el envío de eventos sin depender de un servidor real.

--- a/package.json
+++ b/package.json
@@ -5,9 +5,10 @@
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
-  "scripts": {
+    "scripts": {
     "build": "tsup src/index.ts --dts --format cjs,esm,iife --global-name JourneyFootprints",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "test": "node --test"
   },
   "keywords": ["tracking", "utm", "session"],
   "author": "",

--- a/test/tracker.test.js
+++ b/test/tracker.test.js
@@ -1,0 +1,32 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { createFootprints } from '../dist/index.js';
+
+test('tracks events with fake data', async () => {
+  const calls = [];
+  const fakeFetch = async (_url, options) => {
+    calls.push(JSON.parse(options.body));
+    return {
+      ok: true,
+      status: 201,
+      headers: { get: () => 'session-456' }
+    };
+  };
+
+  const tracker = createFootprints({
+    endpoint: 'https://example.com',
+    user: 'user-123',
+    sessionId: 'session-123',
+    fetchImpl: fakeFetch
+  });
+
+  const result = await tracker.track('signup', { plan: 'free' });
+
+  assert.strictEqual(result.ok, true);
+  assert.strictEqual(result.status, 201);
+  assert.strictEqual(calls.length, 1);
+  assert.strictEqual(calls[0].event, 'signup');
+  assert.strictEqual(calls[0].plan, 'free');
+  assert.strictEqual(calls[0].user, 'user-123');
+  assert.strictEqual(tracker.getSessionId(), 'session-456');
+});


### PR DESCRIPTION
This pull request adds multi-language support to the documentation, introduces a comprehensive README in Portuguese and Spanish, and adds an automated test script with a sample test for the tracker. The main changes are grouped as follows:

**Documentation and Internationalization:**

* Expanded the `README.md` to include full documentation in Portuguese and Spanish, covering features, installation, usage in different frameworks, API, and testing instructions. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R116) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L22-R126) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L32-R138) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L43-R147) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L56-R160) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L66-R170) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R194-R301)

**Testing and Tooling:**

* Added a `test` script to `package.json` to run tests using Node's test runner.
* Added a new test file `test/tracker.test.js` that verifies event tracking with a fake `fetch` implementation, ensuring the tracker works as expected without a real server.