### PR TITLE
docs: reorder languages and add Vue composition example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,106 +1,6 @@
 # JourneyFootprints.js
 
-> Português | [English](#english) | [Español](#español)
-
-## Português
-
-Biblioteca JavaScript leve focada na captura de dados de sessão e parâmetros UTM. Ela roda no navegador e pode ser consumida via CDN ou instalada com npm, pnpm ou yarn.
-
-### Recursos
-
-- Captura `sessionId`, `user` e idioma
-- Lê parâmetros UTM da URL ou os aceita explicitamente
-- Envia eventos para um endpoint configurável
-- Pequeno e agnóstico de framework
-
-### Instalação
-
-```bash
-npm install journey-footprints
-# ou
-pnpm add journey-footprints
-# ou
-yarn add journey-footprints
-```
-
-#### CDN
-
-```html
-<script src="https://unpkg.com/journey-footprints/dist/index.global.js"></script>
-<script>
-  const tracker = JourneyFootprints.createFootprints({ user: '42' });
-  tracker.track('page-view');
-</script>
-```
-
-## Uso
-
-### React
-
-```jsx
-import { createFootprints } from 'journey-footprints';
-
-const tracker = createFootprints({ user: '42' });
-tracker.track('page-view');
-```
-
-### Vue
-
-```js
-import { createFootprints } from 'journey-footprints';
-
-export default {
-  setup() {
-    const tracker = createFootprints();
-    tracker.track('page-view');
-  }
-};
-```
-
-### Svelte
-
-```svelte
-<script>
-  import { createFootprints } from 'journey-footprints';
-  const tracker = createFootprints();
-  tracker.track('page-view');
-</script>
-```
-
-## API
-
-```ts
-createFootprints(options?: {
-  endpoint?: string;
-  sessionId?: string | null;
-  user?: string;
-  utmSource?: string;
-  utmMedium?: string;
-  utmCampaign?: string;
-  utmTerm?: string;
-  utmContent?: string;
-  language?: string;
-})
-```
-
-Retorna um rastreador com métodos:
-
-- `track(event, data?)` – envia um evento
-- `setUser(user)`
-- `setSessionId(sessionId)`
-- `getSessionId()`
-
-O idioma padrão é o do navegador quando não informado.
-
-## Testes com dados fictícios
-
-```bash
-npm test
-```
-
-Os testes utilizam uma implementação fictícia de `fetch` para validar o envio de eventos sem depender de um servidor real.
-
----
+> English | [Português](#português) | [Español](#español)
 
 ## English
 
@@ -144,17 +44,21 @@ const tracker = createFootprints({ user: '42' });
 tracker.track('page-view');
 ```
 
-#### Vue
+#### Vue (Composition API)
 
-```js
+Use the tracker inside Vue's Composition API by creating it within a `<script setup>` block and tracking events on a lifecycle hook:
+
+```vue
+<script setup>
 import { createFootprints } from 'journey-footprints';
+import { onMounted } from 'vue';
 
-export default {
-  setup() {
-    const tracker = createFootprints();
-    tracker.track('page-view');
-  }
-};
+const tracker = createFootprints();
+
+onMounted(() => {
+  tracker.track('page-view');
+});
+</script>
 ```
 
 #### Svelte
@@ -202,6 +106,110 @@ The tests use a fake `fetch` implementation to validate event delivery without r
 
 ---
 
+## Português
+
+Biblioteca JavaScript leve focada na captura de dados de sessão e parâmetros UTM. Ela roda no navegador e pode ser consumida via CDN ou instalada com npm, pnpm ou yarn.
+
+### Recursos
+
+- Captura `sessionId`, `user` e idioma
+- Lê parâmetros UTM da URL ou os aceita explicitamente
+- Envia eventos para um endpoint configurável
+- Pequeno e agnóstico de framework
+
+### Instalação
+
+```bash
+npm install journey-footprints
+# ou
+pnpm add journey-footprints
+# ou
+yarn add journey-footprints
+```
+
+#### CDN
+
+```html
+<script src="https://unpkg.com/journey-footprints/dist/index.global.js"></script>
+<script>
+  const tracker = JourneyFootprints.createFootprints({ user: '42' });
+  tracker.track('page-view');
+</script>
+```
+
+## Uso
+
+### React
+
+```jsx
+import { createFootprints } from 'journey-footprints';
+
+const tracker = createFootprints({ user: '42' });
+tracker.track('page-view');
+```
+
+### Vue (API de Composição)
+
+Use o tracker com a API de Composição do Vue criando-o dentro de um bloco `<script setup>` e rastreando eventos em um hook de ciclo de vida:
+
+```vue
+<script setup>
+import { createFootprints } from 'journey-footprints';
+import { onMounted } from 'vue';
+
+const tracker = createFootprints();
+
+onMounted(() => {
+  tracker.track('page-view');
+});
+</script>
+```
+
+### Svelte
+
+```svelte
+<script>
+  import { createFootprints } from 'journey-footprints';
+  const tracker = createFootprints();
+  tracker.track('page-view');
+</script>
+```
+
+## API
+
+```ts
+createFootprints(options?: {
+  endpoint?: string;
+  sessionId?: string | null;
+  user?: string;
+  utmSource?: string;
+  utmMedium?: string;
+  utmCampaign?: string;
+  utmTerm?: string;
+  utmContent?: string;
+  language?: string;
+})
+```
+
+Retorna um rastreador com métodos:
+
+- `track(event, data?)` – envia um evento
+- `setUser(user)`
+- `setSessionId(sessionId)`
+- `getSessionId()`
+
+O idioma padrão é o do navegador quando não informado.
+
+## Testes com dados fictícios
+
+```bash
+npm test
+```
+
+Os testes utilizam uma implementação fictícia de `fetch` para validar o envio de eventos sem depender de um servidor real.
+
+---
+
 ## Español
 
 Rastreador ligero de JavaScript enfocado en capturar datos de sesión y parámetros UTM. Funciona en navegadores y puede consumirse mediante CDN o instalarse con npm, pnpm o yarn.
@@ -244,17 +252,21 @@ const tracker = createFootprints({ user: '42' });
 tracker.track('page-view');
 ```
 
-#### Vue
+#### Vue (API de composición)
 
-```js
+Utiliza el tracker con la API de composición de Vue creándolo dentro de un bloque `<script setup>` y registrando eventos en un hook de ciclo de vida:
+
+```vue
+<script setup>
 import { createFootprints } from 'journey-footprints';
+import { onMounted } from 'vue';
 
-export default {
-  setup() {
-    const tracker = createFootprints();
-    tracker.track('page-view');
-  }
-};
+const tracker = createFootprints();
+
+onMounted(() => {
+  tracker.track('page-view');
+});
+</script>
 ```
 
 #### Svelte


### PR DESCRIPTION
## Summary
- reorder README so English is first
- document Vue usage with Composition API in all languages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bfb43da708332a45e8b77ce85ac5e