### PR TITLE
chore: override deprecated source-map

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
   "devDependencies": {
     "tsup": "^8.5.0",
     "typescript": "^5.2.0"
+  },
+  "overrides": {
+    "source-map": "^0.7.6"
   }
 }


### PR DESCRIPTION
## Summary
- override `source-map` to a stable release to silence deprecation warnings during install

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bfed280e083329c7b40d478e94acd