### PR TITLE
Add dev endpoint test and event list

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,61 @@ Returns a tracker with methods:
 
 Language defaults to the browser language when not provided.
 
+### Event list
+
+Common events you can track include:
+
+- `first_visit`
+- `session_start`
+- `user_engagement`
+- `page_view`
+- `scroll`
+- `click`
+- `file_download`
+- `video_start`
+- `video_progress`
+- `video_complete`
+- `view_search_results`
+- `add_payment_info`
+- `add_shipping_info`
+- `add_to_cart`
+- `add_to_wishlist`
+- `begin_checkout`
+- `purchase`
+- `refund`
+- `remove_from_cart`
+- `select_item`
+- `select_promotion`
+- `view_cart`
+- `view_item`
+- `view_item_list`
+- `view_promotion`
+- `generate_lead`
+- `qualify_lead`
+- `disqualify_lead`
+- `working_lead`
+- `close_convert_lead`
+- `close_unconvert_lead`
+- `sign_up`
+- `tutorial_begin`
+- `tutorial_complete`
+- `login`
+- `logout`
+- `form_submission`
+- `button_click`
+- `modal_open`
+- `lightbox_open`
+- `video_play`
+- `input_focus`
+- `tooltip_click`
+- `ad_view`
+- `ad_click`
+- `apply_job`
+- `contact`
+- `lead`
+- `register_event`
+- `emailCapture`
+
 ### Testing with fake data
 
 ```bash
@@ -200,6 +255,61 @@ Retorna um rastreador com métodos:
 
 O idioma padrão é o do navegador quando não informado.
 
+### Eventos
+
+Eventos comuns que você pode rastrear incluem:
+
+- `first_visit`
+- `session_start`
+- `user_engagement`
+- `page_view`
+- `scroll`
+- `click`
+- `file_download`
+- `video_start`
+- `video_progress`
+- `video_complete`
+- `view_search_results`
+- `add_payment_info`
+- `add_shipping_info`
+- `add_to_cart`
+- `add_to_wishlist`
+- `begin_checkout`
+- `purchase`
+- `refund`
+- `remove_from_cart`
+- `select_item`
+- `select_promotion`
+- `view_cart`
+- `view_item`
+- `view_item_list`
+- `view_promotion`
+- `generate_lead`
+- `qualify_lead`
+- `disqualify_lead`
+- `working_lead`
+- `close_convert_lead`
+- `close_unconvert_lead`
+- `sign_up`
+- `tutorial_begin`
+- `tutorial_complete`
+- `login`
+- `logout`
+- `form_submission`
+- `button_click`
+- `modal_open`
+- `lightbox_open`
+- `video_play`
+- `input_focus`
+- `tooltip_click`
+- `ad_view`
+- `ad_click`
+- `apply_job`
+- `contact`
+- `lead`
+- `register_event`
+- `emailCapture`
+
 ## Testes com dados fictícios
 
 ```bash
@@ -303,6 +413,61 @@ Devuelve un rastreador con métodos:
 - `getSessionId()`
 
 El idioma predeterminado es el del navegador cuando no se proporciona.
+
+### Eventos
+
+Eventos comunes que se pueden rastrear incluyen:
+
+- `first_visit`
+- `session_start`
+- `user_engagement`
+- `page_view`
+- `scroll`
+- `click`
+- `file_download`
+- `video_start`
+- `video_progress`
+- `video_complete`
+- `view_search_results`
+- `add_payment_info`
+- `add_shipping_info`
+- `add_to_cart`
+- `add_to_wishlist`
+- `begin_checkout`
+- `purchase`
+- `refund`
+- `remove_from_cart`
+- `select_item`
+- `select_promotion`
+- `view_cart`
+- `view_item`
+- `view_item_list`
+- `view_promotion`
+- `generate_lead`
+- `qualify_lead`
+- `disqualify_lead`
+- `working_lead`
+- `close_convert_lead`
+- `close_unconvert_lead`
+- `sign_up`
+- `tutorial_begin`
+- `tutorial_complete`
+- `login`
+- `logout`
+- `form_submission`
+- `button_click`
+- `modal_open`
+- `lightbox_open`
+- `video_play`
+- `input_focus`
+- `tooltip_click`
+- `ad_view`
+- `ad_click`
+- `apply_job`
+- `contact`
+- `lead`
+- `register_event`
+- `emailCapture`
 
 ### Pruebas con datos ficticios
 

--- a/test/tracker.test.js
+++ b/test/tracker.test.js
@@ -2,6 +2,10 @@ import test from 'node:test';
 import assert from 'node:assert';
 import { createFootprints } from '../dist/index.js';
 
+const PUBLIC_KEY = 'f246f177-c795-390b-af95-39b0dd01a7fb';
+const ENDPOINT = 'https://dev.micros.services/api/v1/footprints';
+const EVENT = 'register_event';
+
 test('tracks events with fake data', async () => {
   const calls = [];
   const fakeFetch = async (_url, options) => {
@@ -31,20 +35,22 @@ test('tracks events with fake data', async () => {
   assert.strictEqual(tracker.getSessionId(), 'session-456');
 });
 
-test('includes public key header when provided', async () => {
-  const headers = [];
-  const fakeFetch = async (_url, options) => {
-    headers.push(options.headers);
+test('returns request status using dev endpoint', async () => {
+  const calls = [];
+  const fakeFetch = async (url, options) => {
+    calls.push({ url, headers: options.headers });
     return { ok: true, status: 200, headers: { get: () => null } };
   };
 
   const tracker = createFootprints({
-    endpoint: 'https://example.com',
-    publicKey: 'pub-key-123',
+    endpoint: ENDPOINT,
+    publicKey: PUBLIC_KEY,
     fetchImpl: fakeFetch
   });
 
-  await tracker.track('test');
+  const result = await tracker.track(EVENT);
 
-  assert.strictEqual(headers[0]['X-PUBLIC-KEY'], 'pub-key-123');
+  assert.strictEqual(calls[0].url, ENDPOINT);
+  assert.strictEqual(calls[0].headers['X-PUBLIC-KEY'], PUBLIC_KEY);
+  assert.strictEqual(result.status, 200);
 });


### PR DESCRIPTION
## Summary
- add constants for dev endpoint and public key in tests
- verify request status and header in new test
- document common tracking events in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c007fae04833294d0bc55a0436fdc