### PR TITLE
fix: standardize tracking method to use 'page_view' for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ yarn add journey-footprints
 <script src="https://unpkg.com/journey-footprints/dist/index.global.js"></script>
 <script>
   const tracker = JourneyFootprints.createFootprints({ user: '42' });
-  tracker.track('page-view');
+  tracker.track('page_view');
 </script>
 ```
 
@@ -41,7 +41,7 @@ yarn add journey-footprints
 import { createFootprints } from 'journey-footprints';
 
 const tracker = createFootprints({ user: '42' });
-tracker.track('page-view');
+tracker.track('page_view');
 ```
 
 #### Vue (Composition API)
@@ -56,7 +56,7 @@ import { onMounted } from 'vue';
 const tracker = createFootprints();
 
 onMounted(() => {
-  tracker.track('page-view');
+  tracker.track('page_view');
 });
 </script>
 ```
@@ -67,7 +67,7 @@ onMounted(() => {
 <script>
   import { createFootprints } from 'journey-footprints';
   const tracker = createFootprints();
-  tracker.track('page-view');
+  tracker.track('page_view');
 </script>
 ```
 
@@ -188,7 +188,7 @@ yarn add journey-footprints
 <script src="https://unpkg.com/journey-footprints/dist/index.global.js"></script>
 <script>
   const tracker = JourneyFootprints.createFootprints({ user: '42' });
-  tracker.track('page-view');
+  tracker.track('page_view');
 </script>
 ```
 
@@ -200,7 +200,7 @@ yarn add journey-footprints
 import { createFootprints } from 'journey-footprints';
 
 const tracker = createFootprints({ user: '42' });
-tracker.track('page-view');
+tracker.track('page_view');
 ```
 
 ### Vue (API de Composição)
@@ -215,7 +215,7 @@ import { onMounted } from 'vue';
 const tracker = createFootprints();
 
 onMounted(() => {
-  tracker.track('page-view');
+  tracker.track('page_view');
 });
 </script>
 ```
@@ -226,7 +226,7 @@ onMounted(() => {
 <script>
   import { createFootprints } from 'journey-footprints';
   const tracker = createFootprints();
-  tracker.track('page-view');
+  tracker.track('page_view');
 </script>
 ```
 
@@ -347,7 +347,7 @@ yarn add journey-footprints
 <script src="https://unpkg.com/journey-footprints/dist/index.global.js"></script>
 <script>
   const tracker = JourneyFootprints.createFootprints({ user: '42' });
-  tracker.track('page-view');
+  tracker.track('page_view');
 </script>
 ```
 
@@ -359,7 +359,7 @@ yarn add journey-footprints
 import { createFootprints } from 'journey-footprints';
 
 const tracker = createFootprints({ user: '42' });
-tracker.track('page-view');
+tracker.track('page_view');
 ```
 
 #### Vue (API de composición)
@@ -374,7 +374,7 @@ import { onMounted } from 'vue';
 const tracker = createFootprints();
 
 onMounted(() => {
-  tracker.track('page-view');
+  tracker.track('page_view');
 });
 </script>
 ```
@@ -385,7 +385,7 @@ onMounted(() => {
 <script>
   import { createFootprints } from 'journey-footprints';
   const tracker = createFootprints();
-  tracker.track('page-view');
+  tracker.track('page_view');
 </script>
 ```
 


### PR DESCRIPTION
This pull request updates the usage examples in the `README.md` file to use the correct event name for tracking page views. The event name has been changed from `page-view` to `page_view` in all code samples across different frameworks and languages.

**Documentation consistency:**

* Updated all instances of `tracker.track('page-view')` to `tracker.track('page_view')` in vanilla JavaScript, React, Vue (Composition API), and in multiple language sections of the `README.md` to ensure consistency and accuracy in usage examples. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L32-R32) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L44-R44) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L59-R59) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L70-R70) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L191-R191) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L203-R203) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L218-R218) [[8]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L229-R229) [[9]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L350-R350) [[10]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L362-R362) [[11]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L377-R377) [[12]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L388-R388)